### PR TITLE
ci: run tests on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: make test


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs `make test` on push to any branch and on PRs to main
- Uses `go-version-file` to stay in sync with the project's Go version

Closes #20

## Test plan
- [ ] Verify the workflow triggers on push to this branch
- [ ] Confirm tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)