### PR TITLE
Allow removing subscriptions

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -114,7 +114,7 @@ func NewServer(
 			Handler: handlers.CORS(
 				handlers.AllowedOrigins([]string{corsHeader}),
 				handlers.AllowCredentials(),
-				handlers.AllowedMethods([]string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodOptions}),
+				handlers.AllowedMethods([]string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions}),
 				handlers.AllowedHeaders([]string{"content-type"}),
 			)(r),
 		},
@@ -126,6 +126,7 @@ func NewServer(
 	// Subscription management
 	r.HandleFuncE("/api/subscriptions", srvr.postSusbcriptions).Methods(http.MethodPost)
 	r.HandleFuncE("/api/subscriptions", srvr.getSusbcriptions).Methods(http.MethodGet)
+	r.HandleFuncE("/api/subscriptions/{subscriptionID}", srvr.deleteSubscription).Methods(http.MethodDelete)
 
 	// Timeline view
 	r.HandleFuncE("/api/timeline", srvr.getTimeline).Methods(http.MethodGet)

--- a/internal/api/timeline.go
+++ b/internal/api/timeline.go
@@ -158,6 +158,20 @@ func (s Server) getSusbcriptions(w http.ResponseWriter, r *http.Request) error {
 	return writeJSON(w, http.StatusCreated, resp)
 }
 
+func (s Server) deleteSubscription(w http.ResponseWriter, r *http.Request) error {
+	var (
+		ctx = r.Context()
+		id  = mux.Vars(r)["subscriptionID"]
+	)
+
+	if err := s.timeline.DeleteSubscription(ctx, id); err != nil {
+		return err
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+	return nil
+}
+
 type TimelineResp struct {
 	Items      []TimelineEntry `json:"items"`
 	Pagination paginationMeta  `json:"pagination"`

--- a/internal/seymour/timeline.go
+++ b/internal/seymour/timeline.go
@@ -7,6 +7,7 @@ import "context"
 type TimelineService interface {
 	CreateSubscription(ctx context.Context, feedID string) error
 	AllSubscriptions(ctx context.Context) ([]Subscription, error)
+	DeleteSubscription(ctx context.Context, id string) error
 	MissingEntries(ctx context.Context) ([]MissingEntry, error)
 	EntriesNeedingJudgement(ctx context.Context, limit uint) ([]TimelineEntry, error)
 	InsertEntry(ctx context.Context, entry TimelineEntry) error

--- a/internal/sqlite/timeline.go
+++ b/internal/sqlite/timeline.go
@@ -37,6 +37,25 @@ func (r Repo) AllSubscriptions(ctx context.Context) ([]seymour.Subscription, err
 	return subs, nil
 }
 
+func (r Repo) DeleteSubscription(ctx context.Context, id string) error {
+	const q = `DELETE FROM subscriptions WHERE id = ?;`
+
+	res, err := r.db.ExecContext(ctx, q, id)
+	if err != nil {
+		return fmt.Errorf("error deleting subscription: %w", err)
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("error checking rows affected: %w", err)
+	}
+	if n == 0 {
+		return seymour.ErrNotFound
+	}
+
+	return nil
+}
+
 func (r Repo) Subscription(ctx context.Context, feedID string) (*seymour.Subscription, error) {
 	const q = `SELECT * FROM subscriptions WHERE feed_id = ?;`
 

--- a/internal/sqlite/timeline_test.go
+++ b/internal/sqlite/timeline_test.go
@@ -1,0 +1,41 @@
+package sqlite_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jdholdren/seymour/internal/seymour"
+)
+
+func TestDeleteSubscription(t *testing.T) {
+	repo := testRepo(t)
+	ctx := context.Background()
+
+	require.NoError(t, repo.CreateSubscription(ctx, "feed-1"))
+
+	subs, err := repo.AllSubscriptions(ctx)
+	require.NoError(t, err)
+	require.Len(t, subs, 1)
+
+	require.NoError(t, repo.DeleteSubscription(ctx, subs[0].ID))
+
+	subs, err = repo.AllSubscriptions(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, subs)
+}
+
+func TestDeleteSubscription_NotFound(t *testing.T) {
+	repo := testRepo(t)
+	ctx := context.Background()
+
+	err := repo.DeleteSubscription(ctx, "does-not-exist")
+	require.Error(t, err)
+
+	var sErr *seymour.Error
+	require.ErrorAs(t, err, &sErr)
+	assert.Equal(t, http.StatusNotFound, sErr.Status)
+}


### PR DESCRIPTION
## Summary
- Adds `DeleteSubscription` to `TimelineService` and its sqlite implementation
- Adds `DELETE /api/subscriptions/{subscriptionID}` endpoint
- Allows `DELETE` in CORS allowed methods

Closes #3

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)