### PR TITLE
Scope subscriptions/timeline to users, enforce session auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Seymour is an RSS feed aggregator with a curated timeline, moving from single-tenant to multi-tenant. Users subscribe to RSS feeds, and a Temporal worker syncs feeds, builds a timeline, then judges entries to decide what gets surfaced. The frontend is a separate project (expected at localhost:3000).
 
-A `UserService` (`internal/seymour/user.go`, implemented in `internal/sqlite/users.go`) and GitHub OAuth login (`internal/api/oauth.go`) exist, but nothing in the API enforces auth yet — the session cookie is issued/cleared, but no middleware reads it and there's no "who am I" endpoint.
+A `UserService` (`internal/seymour/user.go`, implemented in `internal/sqlite/users.go`) and GitHub OAuth login (`internal/api/oauth.go`) exist. `internal/api/auth.go`'s `requireAuth` middleware enforces the session cookie on every route except `/api/viewer` (which doubles as the "who am I" check), `/api/oauth-login/gh`, `/api/oauth-callback/gh`, and `/api/logout`. `subscriptions`/`timeline_entries` carry a `user_id`; `feeds`/`feed_entries` stay a shared global cache (deduped by URL) with no owner.
 
 The judging step is a seam: `activities.JudgeEntries` in `internal/worker/judge.go` currently approves every entry. Replace its body to introduce a real curation strategy — the surrounding workflow, batching, and persistence already exist.
 
@@ -60,11 +60,14 @@ SQLite with connection flags `-txlock=immediate -busy_timeout=5000`. Migrations 
 
 ## API Endpoints
 
-- `GET /api/viewer` — Viewer info
-- `POST /api/subscriptions` — Subscribe to feed (triggers CreateFeed workflow)
-- `GET /api/subscriptions` — List subscriptions
-- `GET /api/timeline` — Paginated curated timeline (supports `feed_id` filter)
-- `GET /api/feed-entries/{feedEntryID}` — Full article content via go-readability
+All routes below except `/api/viewer`, `/api/oauth-login/gh`, `/api/oauth-callback/gh`, and `/api/logout` require a valid `session` cookie (enforced by `requireAuth` middleware in `internal/api/auth.go`).
+
+- `GET /api/viewer` — Viewer info; works logged-out too (returns empty subscriptions, no `user` field)
+- `POST /api/users/{userID}/subscriptions` — Subscribe to feed (triggers CreateFeed workflow). `{userID}` must match the session's user
+- `GET /api/users/{userID}/subscriptions` — List subscriptions for that user. `{userID}` must match the session's user
+- `DELETE /api/subscriptions/{subscriptionID}` — Delete a subscription; ownership is checked by fetching the subscription and comparing its `user_id` to the session
+- `GET /api/users/{userID}/timeline` — Paginated curated timeline for that user (supports `feed_id` filter). `{userID}` must match the session's user
+- `GET /api/feed-entries/{feedEntryID}` — Full article content via go-readability; any authenticated user can read any entry (feeds/entries are a shared global cache, not user-owned)
 - `GET /api/oauth-login/gh` — Start GitHub OAuth login; redirects to GitHub. Accepts `?s=<path>` for where to send the browser (on `FRONTEND_URL`) after login succeeds, defaults to `/`
 - `GET /api/oauth-callback/gh` — GitHub OAuth callback; verifies state, ensures the user via `UserService`, sets the `session` cookie, redirects to `FRONTEND_URL` + the requested path
 - `POST /api/logout` — Clears the `session` cookie

--- a/apis/v1/viewer.go
+++ b/apis/v1/viewer.go
@@ -2,7 +2,14 @@ package v1
 
 // Viewer is the response of GET /api/viewer.
 type Viewer struct {
+	User          *ViewerUser                   `json:"user,omitempty"`
 	Subscriptions map[string]ViewerSubscription `json:"subscriptions"`
+}
+
+// ViewerUser describes the authenticated user, if any.
+type ViewerUser struct {
+	ID            string `json:"id"`
+	PreferredName string `json:"preferred_name,omitempty"`
 }
 
 // ViewerSubscription describes a single subscription as seen by the viewer.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -122,23 +122,28 @@ func NewServer(
 	}
 
 	r.Use(accessLogMiddleware) // Log everything
+
+	// Public routes: viewer works logged-out (it's the "who am I" check), and
+	// the oauth/logout routes obviously can't require a session yet.
 	r.HandleFuncE("/api/viewer", srvr.handleViewer).Methods(http.MethodGet)
-
-	// Subscription management
-	r.HandleFuncE("/api/subscriptions", srvr.postSusbcriptions).Methods(http.MethodPost)
-	r.HandleFuncE("/api/subscriptions", srvr.getSusbcriptions).Methods(http.MethodGet)
-	r.HandleFuncE("/api/subscriptions/{subscriptionID}", srvr.deleteSubscription).Methods(http.MethodDelete)
-
-	// Timeline view
-	r.HandleFuncE("/api/timeline", srvr.getTimeline).Methods(http.MethodGet)
-
-	// Reader view
-	r.HandleFuncE("/api/feed-entries/{feedEntryID}", srvr.getFeedEntry).Methods(http.MethodGet)
-
-	// GitHub OAuth login
 	r.HandleFuncE("/api/oauth-login/gh", srvr.startGithubLogin).Methods(http.MethodGet)
 	r.HandleFuncE("/api/oauth-callback/gh", srvr.githubOAuthCallback).Methods(http.MethodGet)
 	r.HandleFuncE("/api/logout", srvr.logout).Methods(http.MethodPost)
+
+	// Everything else requires a valid session.
+	protected := errRouter{Router: r.PathPrefix("/api").Subrouter()}
+	protected.Use(srvr.requireAuth)
+
+	// Subscription management
+	protected.HandleFuncE("/users/{userID}/subscriptions", srvr.postSusbcriptions).Methods(http.MethodPost)
+	protected.HandleFuncE("/users/{userID}/subscriptions", srvr.getSusbcriptions).Methods(http.MethodGet)
+	protected.HandleFuncE("/subscriptions/{subscriptionID}", srvr.deleteSubscription).Methods(http.MethodDelete)
+
+	// Timeline view
+	protected.HandleFuncE("/users/{userID}/timeline", srvr.getTimeline).Methods(http.MethodGet)
+
+	// Reader view
+	protected.HandleFuncE("/feed-entries/{feedEntryID}", srvr.getFeedEntry).Methods(http.MethodGet)
 
 	return &srvr
 }

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/jdholdren/seymour/internal/seymour"
+)
+
+type ctxKey int
+
+const userIDCtxKey ctxKey = iota
+
+// sessionUserID reads and decodes the session cookie, returning the user ID
+// and whether a valid session was present.
+func (s Server) sessionUserID(r *http.Request) (string, bool) {
+	cookie, err := r.Cookie(sessionCookie)
+	if err != nil {
+		return "", false
+	}
+
+	var sess session
+	if err := s.secureCookie.Decode(sessionCookie, cookie.Value, &sess); err != nil {
+		return "", false
+	}
+
+	return sess.UserID, true
+}
+
+// requireAuth rejects requests without a valid session, otherwise attaches
+// the session's user ID to the request context.
+func (s Server) requireAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := s.sessionUserID(r)
+		if !ok {
+			sErr := seymour.E("unauthorized", http.StatusUnauthorized)
+			if err := writeJSON(w, sErr.Status, sErr); err != nil {
+				slog.Error("error writing response", "error", err)
+			}
+			return
+		}
+
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), userIDCtxKey, userID)))
+	})
+}
+
+// userIDFromContext returns the user ID that requireAuth attached to the request context.
+func userIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(userIDCtxKey).(string)
+	return id
+}

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -45,8 +45,8 @@ func (s Server) requireAuth(next http.Handler) http.Handler {
 	})
 }
 
-// userIDFromContext returns the user ID that requireAuth attached to the request context.
-func userIDFromContext(ctx context.Context) string {
+// ctxUserID returns the user ID that requireAuth attached to the request context.
+func ctxUserID(ctx context.Context) string {
 	id, _ := ctx.Value(userIDCtxKey).(string)
 	return id
 }

--- a/internal/api/timeline.go
+++ b/internal/api/timeline.go
@@ -58,7 +58,7 @@ func (s Server) postSusbcriptions(w http.ResponseWriter, r *http.Request) error 
 		userID = mux.Vars(r)["userID"]
 		body   apiv1.PostSubscriptionReq
 	)
-	if userID != userIDFromContext(ctx) {
+	if userID != ctxUserID(ctx) {
 		return seymour.E("forbidden", http.StatusForbidden)
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -95,7 +95,7 @@ func (s Server) getSusbcriptions(w http.ResponseWriter, r *http.Request) error {
 		ctx    = r.Context()
 		userID = mux.Vars(r)["userID"]
 	)
-	if userID != userIDFromContext(ctx) {
+	if userID != ctxUserID(ctx) {
 		return seymour.E("forbidden", http.StatusForbidden)
 	}
 
@@ -150,7 +150,7 @@ func (s Server) deleteSubscription(w http.ResponseWriter, r *http.Request) error
 	if err != nil {
 		return err
 	}
-	if sub.UserID != userIDFromContext(ctx) {
+	if sub.UserID != ctxUserID(ctx) {
 		return seymour.E("forbidden", http.StatusForbidden)
 	}
 
@@ -168,7 +168,7 @@ func (s Server) getTimeline(w http.ResponseWriter, r *http.Request) error {
 		userID = mux.Vars(r)["userID"]
 		feedID = r.URL.Query().Get("feed_id")
 	)
-	if userID != userIDFromContext(ctx) {
+	if userID != ctxUserID(ctx) {
 		return seymour.E("forbidden", http.StatusForbidden)
 	}
 

--- a/internal/api/timeline.go
+++ b/internal/api/timeline.go
@@ -54,9 +54,13 @@ func apiFeed(f seymour.Feed) apiv1.FeedResp {
 
 func (s Server) postSusbcriptions(w http.ResponseWriter, r *http.Request) error {
 	var (
-		ctx  = r.Context()
-		body apiv1.PostSubscriptionReq
+		ctx    = r.Context()
+		userID = mux.Vars(r)["userID"]
+		body   apiv1.PostSubscriptionReq
 	)
+	if userID != userIDFromContext(ctx) {
+		return seymour.E("forbidden", http.StatusForbidden)
+	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		return seymour.E(err, http.StatusBadRequest)
 	}
@@ -79,7 +83,7 @@ func (s Server) postSusbcriptions(w http.ResponseWriter, r *http.Request) error 
 	}
 
 	// Add the feed to the subscriptions
-	if err := s.timeline.CreateSubscription(ctx, feed.ID); err != nil {
+	if err := s.timeline.CreateSubscription(ctx, userID, feed.ID); err != nil {
 		return err
 	}
 
@@ -88,10 +92,14 @@ func (s Server) postSusbcriptions(w http.ResponseWriter, r *http.Request) error 
 
 func (s Server) getSusbcriptions(w http.ResponseWriter, r *http.Request) error {
 	var (
-		ctx = r.Context()
+		ctx    = r.Context()
+		userID = mux.Vars(r)["userID"]
 	)
+	if userID != userIDFromContext(ctx) {
+		return seymour.E("forbidden", http.StatusForbidden)
+	}
 
-	subs, err := s.timeline.AllSubscriptions(ctx)
+	subs, err := s.timeline.AllSubscriptions(ctx, userID)
 	if err != nil {
 		return err
 	}
@@ -138,6 +146,14 @@ func (s Server) deleteSubscription(w http.ResponseWriter, r *http.Request) error
 		id  = mux.Vars(r)["subscriptionID"]
 	)
 
+	sub, err := s.timeline.Subscription(ctx, id)
+	if err != nil {
+		return err
+	}
+	if sub.UserID != userIDFromContext(ctx) {
+		return seymour.E("forbidden", http.StatusForbidden)
+	}
+
 	if err := s.timeline.DeleteSubscription(ctx, id); err != nil {
 		return err
 	}
@@ -149,13 +165,18 @@ func (s Server) deleteSubscription(w http.ResponseWriter, r *http.Request) error
 func (s Server) getTimeline(w http.ResponseWriter, r *http.Request) error {
 	var (
 		ctx    = r.Context()
+		userID = mux.Vars(r)["userID"]
 		feedID = r.URL.Query().Get("feed_id")
 	)
+	if userID != userIDFromContext(ctx) {
+		return seymour.E("forbidden", http.StatusForbidden)
+	}
 
 	// Parse pagination parameters
 	limit, offset := parsePaginationParams(r, 20, 100) // default=20, max=100
 
 	args := seymour.TimelineEntriesArgs{
+		UserID: userID,
 		Status: seymour.TimelineEntryStatusApproved,
 		FeedID: feedID,
 		Limit:  uint64(limit),

--- a/internal/api/viewer.go
+++ b/internal/api/viewer.go
@@ -9,7 +9,19 @@ import (
 func (s Server) handleViewer(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
-	subs, err := s.timeline.AllSubscriptions(ctx)
+	userID, ok := s.sessionUserID(r)
+	if !ok {
+		return writeJSON(w, http.StatusOK, apiv1.Viewer{
+			Subscriptions: map[string]apiv1.ViewerSubscription{},
+		})
+	}
+
+	user, err := s.users.User(ctx, userID)
+	if err != nil {
+		return err
+	}
+
+	subs, err := s.timeline.AllSubscriptions(ctx, userID)
 	if err != nil {
 		return err
 	}
@@ -41,7 +53,16 @@ func (s Server) handleViewer(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
+	var preferredName string
+	if user.PreferredName != nil {
+		preferredName = *user.PreferredName
+	}
+
 	return writeJSON(w, http.StatusOK, apiv1.Viewer{
+		User: &apiv1.ViewerUser{
+			ID:            user.ID,
+			PreferredName: preferredName,
+		},
 		Subscriptions: viewerSubs,
 	})
 }

--- a/internal/migrations/202501010_initial_schema.down.sql
+++ b/internal/migrations/202501010_initial_schema.down.sql
@@ -4,8 +4,9 @@
 -- Drop indexes first
 DROP INDEX IF EXISTS idx_timeline_entries_status_requires_judgement;
 DROP INDEX IF EXISTS idx_timeline_entries_status_approved;
+DROP INDEX IF EXISTS idx_timeline_entries_user_status;
 DROP INDEX IF EXISTS idx_timeline_entries_status;
-DROP INDEX IF EXISTS idx_subscriptions_feed_id;
+DROP INDEX IF EXISTS idx_subscriptions_user_feed;
 
 -- Drop tables
 DROP TABLE IF EXISTS timeline_entries;

--- a/internal/migrations/202501010_initial_schema.up.sql
+++ b/internal/migrations/202501010_initial_schema.up.sql
@@ -24,16 +24,18 @@ CREATE TABLE feed_entries (
 	link VARCHAR(256) NOT NULL
 );
 
--- Subscriptions table: tracks which feeds are subscribed to (single-tenant)
+-- Subscriptions table: tracks which feeds a user is subscribed to
 CREATE TABLE subscriptions (
 	id TEXT PRIMARY KEY,
+	user_id TEXT NOT NULL,
 	feed_id TEXT NOT NULL,
 	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
--- Timeline entries table: curated feed entries for the timeline (single-tenant)
+-- Timeline entries table: curated feed entries for a user's timeline
 CREATE TABLE timeline_entries (
 	id TEXT PRIMARY KEY,
+	user_id TEXT NOT NULL,
 	feed_entry_id TEXT NOT NULL,
 	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	status TEXT NOT NULL,
@@ -41,9 +43,10 @@ CREATE TABLE timeline_entries (
 );
 
 -- Indexes for subscriptions
-CREATE UNIQUE INDEX idx_subscriptions_feed_id ON subscriptions(feed_id);
+CREATE UNIQUE INDEX idx_subscriptions_user_feed ON subscriptions(user_id, feed_id);
 
 -- Indexes for timeline entries
 CREATE INDEX idx_timeline_entries_status ON timeline_entries(status);
+CREATE INDEX idx_timeline_entries_user_status ON timeline_entries(user_id, status);
 CREATE INDEX idx_timeline_entries_status_approved ON timeline_entries(status) WHERE status = 'approved';
 CREATE INDEX idx_timeline_entries_status_requires_judgement ON timeline_entries(status) WHERE status = 'requires_judgement';

--- a/internal/seymour/timeline.go
+++ b/internal/seymour/timeline.go
@@ -5,8 +5,9 @@ import "context"
 // TimelineService provides data operations for the curated timeline and
 // the subscriptions that feed it.
 type TimelineService interface {
-	CreateSubscription(ctx context.Context, feedID string) error
-	AllSubscriptions(ctx context.Context) ([]Subscription, error)
+	CreateSubscription(ctx context.Context, userID, feedID string) error
+	AllSubscriptions(ctx context.Context, userID string) ([]Subscription, error)
+	Subscription(ctx context.Context, id string) (Subscription, error)
 	DeleteSubscription(ctx context.Context, id string) error
 	MissingEntries(ctx context.Context) ([]MissingEntry, error)
 	EntriesNeedingJudgement(ctx context.Context, limit uint) ([]TimelineEntry, error)
@@ -19,6 +20,7 @@ type TimelineService interface {
 // Subscription represents a subscription to a feed.
 type Subscription struct {
 	ID        string `db:"id"`
+	UserID    string `db:"user_id"`
 	FeedID    string `db:"feed_id"`
 	CreatedAt DBTime `db:"created_at"`
 }
@@ -26,6 +28,7 @@ type Subscription struct {
 // TimelineEntry represents an entry in the timeline.
 type TimelineEntry struct {
 	ID          string `db:"id"`
+	UserID      string `db:"user_id"`
 	FeedEntryID string `db:"feed_entry_id"`
 	CreatedAt   DBTime `db:"created_at"`
 	FeedID      string `db:"feed_id"`
@@ -34,14 +37,16 @@ type TimelineEntry struct {
 	Status TimelineEntryStatus `db:"status"`
 }
 
-// MissingEntry is an instance where a feed entry should have been added to the timeline.
+// MissingEntry is an instance where a feed entry should have been added to a user's timeline.
 type MissingEntry struct {
+	UserID      string `db:"user_id"`
 	FeedEntryID string `db:"feed_entry_id"`
 	FeedID      string `db:"feed_id"`
 }
 
 // TimelineEntriesArgs holds arguments for filtering timeline entries.
 type TimelineEntriesArgs struct {
+	UserID string              // Required: scope to a single user
 	Status TimelineEntryStatus // To optionally filter by status
 	FeedID string              // To optionally filter by feed
 	Limit  uint64              // To optionally limit the number of entries returned

--- a/internal/sqlite/timeline.go
+++ b/internal/sqlite/timeline.go
@@ -2,6 +2,8 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
@@ -15,22 +17,22 @@ const (
 	timelineEntryNamespace = "tl-entry"
 )
 
-func (r Repo) CreateSubscription(ctx context.Context, feedID string) error {
-	const q = `INSERT OR IGNORE INTO subscriptions (id, feed_id) VALUES (?, ?);`
+func (r Repo) CreateSubscription(ctx context.Context, userID, feedID string) error {
+	const q = `INSERT OR IGNORE INTO subscriptions (id, user_id, feed_id) VALUES (?, ?, ?);`
 
 	id := fmt.Sprintf("%s-%s", uuid.New().String(), subscriptionNamespace)
-	if _, err := r.db.ExecContext(ctx, q, id, feedID); err != nil {
+	if _, err := r.db.ExecContext(ctx, q, id, userID, feedID); err != nil {
 		return fmt.Errorf("error creating subscription: %w", err)
 	}
 
 	return nil
 }
 
-func (r Repo) AllSubscriptions(ctx context.Context) ([]seymour.Subscription, error) {
-	const q = `SELECT * FROM subscriptions;`
+func (r Repo) AllSubscriptions(ctx context.Context, userID string) ([]seymour.Subscription, error) {
+	const q = `SELECT * FROM subscriptions WHERE user_id = ?;`
 
 	var subs []seymour.Subscription
-	if err := r.db.SelectContext(ctx, &subs, q); err != nil {
+	if err := r.db.SelectContext(ctx, &subs, q, userID); err != nil {
 		return nil, fmt.Errorf("error selecting subscriptions: %s", err)
 	}
 
@@ -56,27 +58,31 @@ func (r Repo) DeleteSubscription(ctx context.Context, id string) error {
 	return nil
 }
 
-func (r Repo) Subscription(ctx context.Context, feedID string) (*seymour.Subscription, error) {
-	const q = `SELECT * FROM subscriptions WHERE feed_id = ?;`
+func (r Repo) Subscription(ctx context.Context, id string) (seymour.Subscription, error) {
+	const q = `SELECT * FROM subscriptions WHERE id = ?;`
 
 	var sub seymour.Subscription
-	if err := r.db.GetContext(ctx, &sub, q, feedID); err != nil {
-		return nil, fmt.Errorf("error selecting subscription: %s", err)
+	err := r.db.GetContext(ctx, &sub, q, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return seymour.Subscription{}, seymour.ErrNotFound
+	}
+	if err != nil {
+		return seymour.Subscription{}, fmt.Errorf("error selecting subscription: %s", err)
 	}
 
-	return &sub, nil
+	return sub, nil
 }
 
 func (r Repo) MissingEntries(ctx context.Context) ([]seymour.MissingEntry, error) {
 	const q = `
 	SELECT
+		subs.user_id AS user_id,
 		fe.feed_id AS feed_id,
 		fe.id AS feed_entry_id
 	FROM
 		feed_entries fe
-		INNER JOIN feeds ON feeds.id = fe.feed_id
-		INNER JOIN subscriptions subs ON subs.feed_id = feeds.id
-		LEFT JOIN timeline_entries ts ON ts.feed_entry_id = fe.id
+		INNER JOIN subscriptions subs ON subs.feed_id = fe.feed_id
+		LEFT JOIN timeline_entries ts ON ts.feed_entry_id = fe.id AND ts.user_id = subs.user_id
 		WHERE ts.feed_entry_id IS NULL ;
 	`
 
@@ -91,10 +97,12 @@ func (r Repo) MissingEntries(ctx context.Context) ([]seymour.MissingEntry, error
 func (r Repo) InsertEntry(ctx context.Context, entry seymour.TimelineEntry) error {
 	const q = `INSERT OR IGNORE INTO timeline_entries (
 		id,
+		user_id,
 		feed_entry_id,
 		status,
 		feed_id
 	) VALUES (
+		?,
 		?,
 		?,
 		?,
@@ -103,7 +111,7 @@ func (r Repo) InsertEntry(ctx context.Context, entry seymour.TimelineEntry) erro
 	`
 
 	entry.ID = fmt.Sprintf("%s-%s", uuid.New().String(), timelineEntryNamespace)
-	if _, err := r.db.ExecContext(ctx, q, entry.ID, entry.FeedEntryID, entry.Status, entry.FeedID); err != nil {
+	if _, err := r.db.ExecContext(ctx, q, entry.ID, entry.UserID, entry.FeedEntryID, entry.Status, entry.FeedID); err != nil {
 		return fmt.Errorf("error inserting entry: %s", err)
 	}
 
@@ -143,8 +151,8 @@ func (r Repo) UpdateTimelineEntry(ctx context.Context, id string, status seymour
 }
 
 func (r Repo) TimelineEntries(ctx context.Context, args seymour.TimelineEntriesArgs) ([]seymour.TimelineEntry, error) {
-	q := sq.Select("id", "feed_entry_id", "created_at", "status", "feed_id").From("timeline_entries").OrderBy("created_at DESC")
-	where := sq.Eq{}
+	q := sq.Select("id", "user_id", "feed_entry_id", "created_at", "status", "feed_id").From("timeline_entries").OrderBy("created_at DESC")
+	where := sq.Eq{"user_id": args.UserID}
 	if args.Status != "" {
 		where["status"] = args.Status
 	}
@@ -177,7 +185,7 @@ func (r Repo) TimelineEntries(ctx context.Context, args seymour.TimelineEntriesA
 
 func (r Repo) CountTimelineEntries(ctx context.Context, args seymour.TimelineEntriesArgs) (int, error) {
 	q := sq.Select("COUNT(*)").From("timeline_entries")
-	where := sq.Eq{}
+	where := sq.Eq{"user_id": args.UserID}
 	if args.Status != "" {
 		where["status"] = args.Status
 	}

--- a/internal/sqlite/timeline_test.go
+++ b/internal/sqlite/timeline_test.go
@@ -15,17 +15,30 @@ func TestDeleteSubscription(t *testing.T) {
 	repo := testRepo(t)
 	ctx := context.Background()
 
-	require.NoError(t, repo.CreateSubscription(ctx, "feed-1"))
+	require.NoError(t, repo.CreateSubscription(ctx, "user-1", "feed-1"))
 
-	subs, err := repo.AllSubscriptions(ctx)
+	subs, err := repo.AllSubscriptions(ctx, "user-1")
 	require.NoError(t, err)
 	require.Len(t, subs, 1)
 
 	require.NoError(t, repo.DeleteSubscription(ctx, subs[0].ID))
 
-	subs, err = repo.AllSubscriptions(ctx)
+	subs, err = repo.AllSubscriptions(ctx, "user-1")
 	require.NoError(t, err)
 	assert.Empty(t, subs)
+}
+
+func TestAllSubscriptions_ScopedByUser(t *testing.T) {
+	repo := testRepo(t)
+	ctx := context.Background()
+
+	require.NoError(t, repo.CreateSubscription(ctx, "user-1", "feed-1"))
+	require.NoError(t, repo.CreateSubscription(ctx, "user-2", "feed-1"))
+
+	subs, err := repo.AllSubscriptions(ctx, "user-1")
+	require.NoError(t, err)
+	require.Len(t, subs, 1)
+	assert.Equal(t, "user-1", subs[0].UserID)
 }
 
 func TestDeleteSubscription_NotFound(t *testing.T) {

--- a/internal/worker/activities.go
+++ b/internal/worker/activities.go
@@ -119,6 +119,7 @@ func (a activities) InsertMissingTimelineEntries(ctx context.Context) (int, erro
 	// Keep track of affected entries
 	for _, m := range missing {
 		if err := a.timeline.InsertEntry(ctx, seymour.TimelineEntry{
+			UserID:      m.UserID,
 			FeedEntryID: m.FeedEntryID,
 			Status:      seymour.TimelineEntryStatusRequiresJudgement,
 			FeedID:      m.FeedID,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -279,6 +279,8 @@ components:
             $ref: '#/components/schemas/V1ViewerSubscription'
           nullable: true
           type: object
+        user:
+          $ref: '#/components/schemas/V1ViewerUser'
       type: object
     V1ViewerSubscription:
       properties:
@@ -287,5 +289,12 @@ components:
         feed_id:
           type: string
         name:
+          type: string
+      type: object
+    V1ViewerUser:
+      properties:
+        id:
+          type: string
+        preferred_name:
           type: string
       type: object


### PR DESCRIPTION
## Summary
- `subscriptions`/`timeline_entries` now carry `user_id`; `feeds`/`feed_entries` stay a shared global cache (deduped by URL), unchanged. Judging is per-user: the same `feed_entry` can be approved for one subscriber and rejected for another.
- New `requireAuth` middleware (`internal/api/auth.go`) protects every `/api` route except `/api/viewer`, oauth login/callback, and logout. `/api/viewer` now reflects the logged-in user (or an empty/anonymous shape if logged out).
- `/api/users/{userID}/subscriptions` and `/api/users/{userID}/timeline` check the path `{userID}` against the session inline. `DELETE /api/subscriptions/{id}` infers ownership by fetching the subscription first and comparing its `user_id`.
- Schema edited in place on the initial migration (no new migration file) since nothing had shipped against these tables yet; local dev DB needs a fresh migrate (delete `data/citadel/citadel.sqlite`) to pick up the new columns.
- `CLAUDE.md` and `openapi.yaml` regenerated/updated to match.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] Manual e2e against a running container with two fabricated user sessions: viewer logged-out/logged-in, 401 on protected routes with no/garbage cookie, 403 on path/session mismatch and on deleting another user's subscription, correct per-user scoping on subscriptions/timeline, 204 delete for the real owner
- [ ] Real two-account GitHub OAuth login smoke test (not run — needs live GitHub OAuth creds/browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)