### PR TITLE
Add status and publish-date filters to the timeline endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ All routes below except `/api/viewer`, `/api/oauth-login/gh`, `/api/oauth-callba
 - `POST /api/users/{userID}/subscriptions` — Subscribe to feed (triggers CreateFeed workflow). `{userID}` must match the session's user
 - `GET /api/users/{userID}/subscriptions` — List subscriptions for that user. `{userID}` must match the session's user
 - `DELETE /api/subscriptions/{subscriptionID}` — Delete a subscription; ownership is checked by fetching the subscription and comparing its `user_id` to the session
-- `GET /api/users/{userID}/timeline` — Paginated curated timeline for that user (supports `feed_id` filter). `{userID}` must match the session's user
+- `GET /api/users/{userID}/timeline` — Paginated curated timeline for that user (supports `feed_id`, `status` — one of `requires_judgement`/`approved`/`rejected`, defaults to all — and `from`/`to` publish-date filters, RFC3339 or `YYYY-MM-DD`). `{userID}` must match the session's user
 - `GET /api/feed-entries/{feedEntryID}` — Full article content via go-readability; any authenticated user can read any entry (feeds/entries are a shared global cache, not user-owned)
 - `GET /api/oauth-login/gh` — Start GitHub OAuth login; redirects to GitHub. Accepts `?s=<path>` for where to send the browser (on `FRONTEND_URL`) after login succeeds, defaults to `/`
 - `GET /api/oauth-callback/gh` — GitHub OAuth callback; verifies state, ensures the user via `UserService`, sets the `session` cookie, redirects to `FRONTEND_URL` + the requested path

--- a/cmd/genopenapi/main.go
+++ b/cmd/genopenapi/main.go
@@ -24,6 +24,9 @@ import (
 type (
 	timelineQuery struct {
 		FeedID string `query:"feed_id" description:"Filter the timeline to a single feed."`
+		Status string `query:"status" description:"Filter by entry status (requires_judgement, approved, rejected). Defaults to all statuses."`
+		From   string `query:"from" description:"Only include entries published on or after this date (RFC3339 or YYYY-MM-DD)."`
+		To     string `query:"to" description:"Only include entries published on or before this date (RFC3339 or YYYY-MM-DD)."`
 		Limit  int    `query:"limit" description:"Page size, default 20, max 100."`
 		Offset int    `query:"offset" description:"Pagination offset, default 0."`
 	}
@@ -85,7 +88,7 @@ func main() {
 		},
 		{
 			method: http.MethodGet, path: "/api/timeline", id: "getTimeline", tag: "timeline",
-			summary:   "Get the paginated, curated timeline of approved entries.",
+			summary:   "Get the paginated, curated timeline, optionally filtered by status and publish date.",
 			reqParams: timelineQuery{}, resp: apiv1.TimelineResp{}, status: http.StatusOK,
 		},
 		{

--- a/internal/api/timeline.go
+++ b/internal/api/timeline.go
@@ -162,25 +162,73 @@ func (s Server) deleteSubscription(w http.ResponseWriter, r *http.Request) error
 	return nil
 }
 
+// validTimelineEntryStatuses are the values getTimeline accepts for its
+// ?status= filter.
+var validTimelineEntryStatuses = map[seymour.TimelineEntryStatus]bool{
+	seymour.TimelineEntryStatusRequiresJudgement: true,
+	seymour.TimelineEntryStatusApproved:          true,
+	seymour.TimelineEntryStatusRejected:          true,
+}
+
+// parseTimelineDateParam parses a "from"/"to" query value, accepting either
+// a full RFC3339 timestamp or a bare date (2006-01-02). A bare date is
+// anchored to the start of the day, or the end of the day if endOfDay is
+// true, so ?to=2026-08-05 includes the entire day.
+func parseTimelineDateParam(value string, endOfDay bool) (*time.Time, error) {
+	if value == "" {
+		return nil, nil
+	}
+
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return &t, nil
+	}
+
+	t, err := time.Parse("2006-01-02", value)
+	if err != nil {
+		return nil, fmt.Errorf("must be RFC3339 or YYYY-MM-DD: %s", value)
+	}
+	if endOfDay {
+		t = t.Add(24*time.Hour - time.Nanosecond)
+	}
+
+	return &t, nil
+}
+
 func (s Server) getTimeline(w http.ResponseWriter, r *http.Request) error {
 	var (
 		ctx    = r.Context()
 		userID = mux.Vars(r)["userID"]
-		feedID = r.URL.Query().Get("feed_id")
+		query  = r.URL.Query()
+		feedID = query.Get("feed_id")
+		status = seymour.TimelineEntryStatus(query.Get("status"))
 	)
 	if userID != ctxUserID(ctx) {
 		return seymour.E("forbidden", http.StatusForbidden)
+	}
+	if status != "" && !validTimelineEntryStatuses[status] {
+		return seymour.E(fmt.Sprintf("invalid status: %s", status), http.StatusBadRequest)
+	}
+
+	fromDate, err := parseTimelineDateParam(query.Get("from"), false)
+	if err != nil {
+		return seymour.E(fmt.Sprintf("invalid from: %s", err), http.StatusBadRequest)
+	}
+	toDate, err := parseTimelineDateParam(query.Get("to"), true)
+	if err != nil {
+		return seymour.E(fmt.Sprintf("invalid to: %s", err), http.StatusBadRequest)
 	}
 
 	// Parse pagination parameters
 	limit, offset := parsePaginationParams(r, 20, 100) // default=20, max=100
 
 	args := seymour.TimelineEntriesArgs{
-		UserID: userID,
-		Status: seymour.TimelineEntryStatusApproved,
-		FeedID: feedID,
-		Limit:  uint64(limit),
-		Offset: uint64(offset),
+		UserID:   userID,
+		Status:   status,
+		FeedID:   feedID,
+		FromDate: fromDate,
+		ToDate:   toDate,
+		Limit:    uint64(limit),
+		Offset:   uint64(offset),
 	}
 
 	// Get count and entries

--- a/internal/seymour/timeline.go
+++ b/internal/seymour/timeline.go
@@ -1,6 +1,9 @@
 package seymour
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // TimelineService provides data operations for the curated timeline and
 // the subscriptions that feed it.
@@ -50,6 +53,11 @@ type TimelineEntriesArgs struct {
 	Status TimelineEntryStatus // To optionally filter by status
 	FeedID string              // To optionally filter by feed
 	Limit  uint64              // To optionally limit the number of entries returned
+
+	// To optionally filter by the entry's feed publish date, inclusive on
+	// both ends.
+	FromDate *time.Time
+	ToDate   *time.Time
 
 	// Pagination fields
 	Offset uint64 // Offset for pagination

--- a/internal/sqlite/timeline.go
+++ b/internal/sqlite/timeline.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/google/uuid"
@@ -150,24 +151,48 @@ func (r Repo) UpdateTimelineEntry(ctx context.Context, id string, status seymour
 	return nil
 }
 
-func (r Repo) TimelineEntries(ctx context.Context, args seymour.TimelineEntriesArgs) ([]seymour.TimelineEntry, error) {
-	q := sq.Select("id", "user_id", "feed_entry_id", "created_at", "status", "feed_id").From("timeline_entries").OrderBy("created_at DESC")
-	where := sq.Eq{"user_id": args.UserID}
+// timelineEntriesFilters applies the where clauses (and, when a date filter
+// is present, the join needed to reach feed_entries.publish_time) shared by
+// TimelineEntries and CountTimelineEntries.
+func timelineEntriesFilters(q sq.SelectBuilder, args seymour.TimelineEntriesArgs) sq.SelectBuilder {
+	where := sq.Eq{"timeline_entries.user_id": args.UserID}
 	if args.Status != "" {
-		where["status"] = args.Status
+		where["timeline_entries.status"] = args.Status
 	}
+	if args.FeedID != "" {
+		where["timeline_entries.feed_id"] = args.FeedID
+	}
+	q = q.Where(where)
+
+	if args.FromDate != nil || args.ToDate != nil {
+		q = q.Join("feed_entries ON feed_entries.id = timeline_entries.feed_entry_id")
+		if args.FromDate != nil {
+			q = q.Where(sq.GtOrEq{"feed_entries.publish_time": args.FromDate.Format(time.RFC3339)})
+		}
+		if args.ToDate != nil {
+			q = q.Where(sq.LtOrEq{"feed_entries.publish_time": args.ToDate.Format(time.RFC3339)})
+		}
+	}
+
+	return q
+}
+
+func (r Repo) TimelineEntries(ctx context.Context, args seymour.TimelineEntriesArgs) ([]seymour.TimelineEntry, error) {
+	q := sq.Select(
+		"timeline_entries.id",
+		"timeline_entries.user_id",
+		"timeline_entries.feed_entry_id",
+		"timeline_entries.created_at",
+		"timeline_entries.status",
+		"timeline_entries.feed_id",
+	).From("timeline_entries").OrderBy("timeline_entries.created_at DESC")
+	q = timelineEntriesFilters(q, args)
+
 	if args.Limit > 0 {
 		q = q.Limit(args.Limit)
 	}
 	if args.Offset > 0 {
 		q = q.Offset(args.Offset)
-	}
-	if args.FeedID != "" {
-		q = q.Where("feed_id = ?", args.FeedID)
-	}
-
-	if len(where) > 0 {
-		q = q.Where(where)
 	}
 
 	query, queryArgs, err := q.ToSql()
@@ -185,17 +210,7 @@ func (r Repo) TimelineEntries(ctx context.Context, args seymour.TimelineEntriesA
 
 func (r Repo) CountTimelineEntries(ctx context.Context, args seymour.TimelineEntriesArgs) (int, error) {
 	q := sq.Select("COUNT(*)").From("timeline_entries")
-	where := sq.Eq{"user_id": args.UserID}
-	if args.Status != "" {
-		where["status"] = args.Status
-	}
-	if args.FeedID != "" {
-		q = q.Where("feed_id = ?", args.FeedID)
-	}
-
-	if len(where) > 0 {
-		q = q.Where(where)
-	}
+	q = timelineEntriesFilters(q, args)
 
 	query, queryArgs, err := q.ToSql()
 	if err != nil {

--- a/internal/sqlite/timeline_test.go
+++ b/internal/sqlite/timeline_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/jdholdren/seymour/internal/seymour"
+	"github.com/jdholdren/seymour/internal/sqlite"
 )
 
 func TestDeleteSubscription(t *testing.T) {
@@ -51,4 +53,98 @@ func TestDeleteSubscription_NotFound(t *testing.T) {
 	var sErr *seymour.Error
 	require.ErrorAs(t, err, &sErr)
 	assert.Equal(t, http.StatusNotFound, sErr.Status)
+}
+
+// seedTimelineEntry creates a feed, a feed entry published at publishTime,
+// and a timeline entry pointing to it, returning the timeline entry's ID.
+func seedTimelineEntry(t *testing.T, repo sqlite.Repo, userID, guid string, publishTime time.Time, status seymour.TimelineEntryStatus) string {
+	t.Helper()
+	ctx := context.Background()
+
+	feed, err := repo.InsertFeed(ctx, "https://example.com/"+guid)
+	require.NoError(t, err)
+
+	entries := []seymour.FeedEntry{{
+		FeedID:      feed.ID,
+		Title:       "title",
+		Description: "description",
+		GUID:        guid,
+		Link:        "https://example.com/" + guid,
+		PublishTime: seymour.DBTime{Time: publishTime},
+	}}
+	require.NoError(t, repo.InsertEntries(ctx, entries))
+
+	require.NoError(t, repo.InsertEntry(ctx, seymour.TimelineEntry{
+		UserID:      userID,
+		FeedEntryID: entries[0].ID,
+		FeedID:      feed.ID,
+		Status:      status,
+	}))
+
+	tlEntries, err := repo.TimelineEntries(ctx, seymour.TimelineEntriesArgs{UserID: userID, FeedID: feed.ID})
+	require.NoError(t, err)
+	require.Len(t, tlEntries, 1)
+
+	return tlEntries[0].ID
+}
+
+func TestTimelineEntries_FilterByStatus(t *testing.T) {
+	repo := testRepo(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	seedTimelineEntry(t, repo, "user-1", "approved-entry", now, seymour.TimelineEntryStatusApproved)
+	seedTimelineEntry(t, repo, "user-1", "pending-entry", now, seymour.TimelineEntryStatusRequiresJudgement)
+
+	// No status filter: everything comes back.
+	all, err := repo.TimelineEntries(ctx, seymour.TimelineEntriesArgs{UserID: "user-1"})
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+
+	count, err := repo.CountTimelineEntries(ctx, seymour.TimelineEntriesArgs{UserID: "user-1"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// Narrowed to approved only.
+	approved, err := repo.TimelineEntries(ctx, seymour.TimelineEntriesArgs{UserID: "user-1", Status: seymour.TimelineEntryStatusApproved})
+	require.NoError(t, err)
+	require.Len(t, approved, 1)
+	assert.Equal(t, seymour.TimelineEntryStatusApproved, approved[0].Status)
+}
+
+func TestTimelineEntries_FilterByDateRange(t *testing.T) {
+	repo := testRepo(t)
+	ctx := context.Background()
+
+	older := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	inRange := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
+
+	seedTimelineEntry(t, repo, "user-1", "older-entry", older, seymour.TimelineEntryStatusApproved)
+	seedTimelineEntry(t, repo, "user-1", "in-range-entry", inRange, seymour.TimelineEntryStatusApproved)
+	seedTimelineEntry(t, repo, "user-1", "newer-entry", newer, seymour.TimelineEntryStatusApproved)
+
+	from := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+
+	entries, err := repo.TimelineEntries(ctx, seymour.TimelineEntriesArgs{
+		UserID:   "user-1",
+		FromDate: &from,
+		ToDate:   &to,
+	})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	feedEntries, err := repo.Entries(ctx, []string{entries[0].FeedEntryID})
+	require.NoError(t, err)
+	require.Len(t, feedEntries, 1)
+	assert.Equal(t, "in-range-entry", feedEntries[0].GUID)
+
+	count, err := repo.CountTimelineEntries(ctx, seymour.TimelineEntriesArgs{
+		UserID:   "user-1",
+		FromDate: &from,
+		ToDate:   &to,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -130,6 +130,30 @@ paths:
         schema:
           description: Filter the timeline to a single feed.
           type: string
+      - description: Filter by entry status (requires_judgement, approved, rejected).
+          Defaults to all statuses.
+        in: query
+        name: status
+        schema:
+          description: Filter by entry status (requires_judgement, approved, rejected).
+            Defaults to all statuses.
+          type: string
+      - description: Only include entries published on or after this date (RFC3339
+          or YYYY-MM-DD).
+        in: query
+        name: from
+        schema:
+          description: Only include entries published on or after this date (RFC3339
+            or YYYY-MM-DD).
+          type: string
+      - description: Only include entries published on or before this date (RFC3339
+          or YYYY-MM-DD).
+        in: query
+        name: to
+        schema:
+          description: Only include entries published on or before this date (RFC3339
+            or YYYY-MM-DD).
+          type: string
       - description: Page size, default 20, max 100.
         in: query
         name: limit
@@ -149,7 +173,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/V1TimelineResp'
           description: OK
-      summary: Get the paginated, curated timeline of approved entries.
+      summary: Get the paginated, curated timeline, optionally filtered by status
+        and publish date.
       tags:
       - timeline
   /api/viewer:


### PR DESCRIPTION
## Summary
- `GET /api/users/{userID}/timeline` now accepts `status`, `from`, and `to` query params in addition to the existing `feed_id`.
- `status` — omitted returns entries of **all** statuses (was previously hardcoded to `approved` only). Pass `requires_judgement`, `approved`, or `rejected` to narrow. Invalid values return 400.
- `from` / `to` — filter by the entry's **publish date** (`feed_entries.publish_time`), inclusive on both ends. Accepts RFC3339 or bare `YYYY-MM-DD`; a bare `from` anchors to start-of-day, a bare `to` to end-of-day. Invalid formats return 400.

## ⚠️ Behavior change
The timeline endpoint no longer defaults to `approved`-only entries. Frontend must now pass `status=approved` explicitly to preserve today's "curated timeline" view — see the follow-up prompt for the FE.

## Implementation
- `seymour.TimelineEntriesArgs` gained `FromDate`/`ToDate *time.Time`.
- `internal/sqlite/timeline.go`: shared `timelineEntriesFilters` helper for `TimelineEntries`/`CountTimelineEntries`; joins `feed_entries` only when a date filter is present.
- `internal/api/timeline.go`: parses/validates the new query params.
- Regenerated `openapi.yaml` via `cmd/genopenapi`.
- Added sqlite-level tests for status and date-range filtering.

## Testing
- `go build ./...`
- `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)